### PR TITLE
Fix Input composable parentheses

### DIFF
--- a/converter/src/main/kotlin/de/jensklingenberg/htmltocfw/converter/node/InputNode.kt
+++ b/converter/src/main/kotlin/de/jensklingenberg/htmltocfw/converter/node/InputNode.kt
@@ -20,7 +20,7 @@ class InputNode(private val attrs: List<ComposeAttribute>, val type: String) : M
         val arguments = mutableListOf<String>()
 
         if (attrs.isNotEmpty()) {
-            str += parseAttributes(attrs)
+            arguments.add(parseAttributes(attrs))
         }
 
         if (type.isNotBlank()) {


### PR DESCRIPTION
Fixes the parentheses location for Input nodes. Parsed attributes should be added as an argument for the resulting string.